### PR TITLE
[BugFix] Discord embed, resume views, and scripts loading issues

### DIFF
--- a/website/src/main/java/org/togetherjava/website/Application.java
+++ b/website/src/main/java/org/togetherjava/website/Application.java
@@ -1,10 +1,10 @@
-package org.togetherjava.tjbot.website;
+package org.togetherjava.website;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 /**
- * Spring boot application to serve the bots welcome webpage.
+ * Spring boot application to serve the website.
  */
 @SpringBootApplication
 public class Application {

--- a/website/src/main/java/org/togetherjava/website/package-info.java
+++ b/website/src/main/java/org/togetherjava/website/package-info.java
@@ -1,4 +1,4 @@
 /**
  * Main package for the projects' website.
  */
-package org.togetherjava.tjbot.website;
+package org.togetherjava.website;

--- a/website/src/main/resources/public/index.html
+++ b/website/src/main/resources/public/index.html
@@ -230,14 +230,14 @@
 </footer>
 
 <!-- Scripts -->
-<script src="assets/js/jquery-3.6.1.min.js" async></script>
-<script src="assets/js/jquery.scrollex.min.js" async></script>
-<script src="assets/js/jquery.scrolly.min.js" async></script>
-<script src="assets/js/browser.min.js" async></script>
-<script src="assets/js/breakpoints.min.js" async></script>
-<script src="assets/js/util.js" async></script>
-<script src="assets/js/main.js" async></script>
-<script src="https://cdn.jsdelivr.net/npm/@widgetbot/html-embed@1.0.0"></script>
+<script src="assets/js/jquery-3.6.1.min.js"></script>
+<script src="assets/js/jquery.scrollex.min.js" ></script>
+<script src="assets/js/jquery.scrolly.min.js"></script>
+<script src="assets/js/browser.min.js" ></script>
+<script src="assets/js/breakpoints.min.js" ></script>
+<script src="assets/js/util.js" ></script>
+<script src="assets/js/main.js" ></script>
+<script src="https://cdn.jsdelivr.net/npm/@widgetbot/html-embed@1.3.0"></script>
 
 
 </body>


### PR DESCRIPTION
Found 3 issues: 
1. The unique java main class has a wrong package name.
2. The discord embed is shown in a very small shape.
3. When refreshing the page some objects collide (like the gif in the issue).

![tj-bug-2](https://github.com/user-attachments/assets/c5f01043-0eaf-4c29-ae03-030a89e1277c)

closes #20 